### PR TITLE
Build Docker image & push to hub action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,30 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  IMAGE_NAME: caddydz/caddydz.github.io
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and tag Docker image
+        run: docker build -t ${{ env.IMAGE_NAME }} .
+
+      - name: Push Docker image
+        run: docker push ${{ env.IMAGE_NAME }}


### PR DESCRIPTION
* Added a GitHub actions workflow to automatically build the Docker image and push it to Docker Hub registry to keep the runtime image in sync with the latest changes.